### PR TITLE
Cgo usage of editline (C) library

### DIFF
--- a/prompt.go
+++ b/prompt.go
@@ -1,25 +1,34 @@
 package main
 
+/*
+#cgo LDFLAGS: -ledit
+#include <stdlib.h>
+#include <editline/readline.h>
+*/
+import "C"
+
 import (
-	"bufio"
 	"fmt"
-	"os"
+	"unsafe"
 )
 
 func main() {
 	// Version and Exit Information
-	fmt.Println("Lispy Version 0.0.0.0.1")
-	fmt.Println("Press Ctrl+c to Exit\n")
-	// For reading lines of user input
-	scanner := bufio.NewScanner(os.Stdin)
+	fmt.Println("Lispy Version 0.0.0.0.2")
+	fmt.Println("Pressing Ctrl+c is broken in this version\n")
+	// Prompt for user input
+	prompt := C.CString("lispy> ")
 
 	for {
-		// Prompt
-		fmt.Print("lispy> ")
-		// Read a line of user input
-		scanner.Scan()
-		input := scanner.Text()
+		// Output prompt and get user input
+		raw_input := C.readline(prompt)
+		input := C.GoString(raw_input)
+		// Add input to history
+		C.add_history(raw_input)
 		// Echo input back to user
 		fmt.Printf("No you're a %s\n", input)
+		// Free retrieved input
+		C.free(unsafe.Pointer(raw_input))
 	}
+	C.free(unsafe.Pointer(prompt))
 }


### PR DESCRIPTION
Allows usage of arrow keys to navigate through past commands.

Warning: This usage of editline breaks the Ctrl+C exiting behavior.
After those keys are pressed, newline fails to return user input.
